### PR TITLE
refactor: add frame info duration loop that checks the number of image info to add

### DIFF
--- a/lib/flutter_gif.dart
+++ b/lib/flutter_gif.dart
@@ -7,7 +7,6 @@
 library flutter_gif;
 
 import 'dart:io';
-import 'dart:typed_data';
 import 'dart:ui' as ui show Codec;
 import 'dart:ui';
 
@@ -257,13 +256,15 @@ Future<List<ImageInfo>> fetchGif(ImageProvider provider) async {
     throw Exception("Unsupported image provider");
   }
 
-  ui.Codec codec = await PaintingBinding.instance.instantiateImageCodec(bytes);
-  infos = [];
+  final buffer = await ImmutableBuffer.fromUint8List(bytes);
+  ui.Codec codec =
+      await PaintingBinding.instance.instantiateImageCodecFromBuffer(buffer);
   for (int i = 0; i < codec.frameCount; i++) {
-    FrameInfo frameInfo = await codec.getNextFrame();
-    //scale ??
-    infos.add(ImageInfo(image: frameInfo.image));
+    final frameInfo = await codec.getNextFrame();
+    final duration = frameInfo.duration.inSeconds;
+    for (int sec = 1; sec <= duration; sec++) {
+      infos.add(ImageInfo(image: frameInfo.image));
+    }
   }
-  GifImage.cache.caches.putIfAbsent(key, () => infos);
   return infos;
 }


### PR DESCRIPTION
I noticed that if the current frame contains the same image info, they are only considered as one frame which makes the actual gif unable to play the complete gif frame/duration.

To make things clear, here's an example gif:
![rendered_preview_15](https://user-images.githubusercontent.com/64421849/206624012-520b622d-469c-4e78-a997-22c0ede4c743.gif)

The first( image with #1) frame's duration is 4 seconds but when played, it only shows 1 frame since they're all the same. Then the rest is fine since they're all playing at 1 sec, meaning 1 frame.

So to fix that, I added a validator that loop and checks whether the actual duration/frame was added to the list of `ImageInfo`s.
```dart
    for (int sec = 1; sec <= duration; sec++) {
      infos.add(ImageInfo(image: frameInfo.image));
    }
```

Another thing, I replaced this deprecated method:
```dart
ui.Codec codec = await PaintingBinding.instance.instantiateImageCodec(bytes);
```
`'instantiateImageCodec' is deprecated and shouldn't be used. Use instantiateImageCodecFromBuffer with an ImmutableBuffer instance instead. This feature was deprecated after v2.13.0-1.0.pre..`

by using the suggested:
```dart
  final buffer = await ImmutableBuffer.fromUint8List(bytes);
  ui.Codec codec =
      await PaintingBinding.instance.instantiateImageCodecFromBuffer(buffer);
```