### PR TITLE
Fix instantiateImageCodec issue with Flutter 3.16.9

### DIFF
--- a/lib/flutter_gif.dart
+++ b/lib/flutter_gif.dart
@@ -257,8 +257,7 @@ Future<List<ImageInfo>> fetchGif(ImageProvider provider) async {
   }
 
   final buffer = await ImmutableBuffer.fromUint8List(bytes);
-  ui.Codec codec =
-      await PaintingBinding.instance.instantiateImageCodecFromBuffer(buffer);
+  ui.Codec codec = await instantiateImageCodecFromBuffer(buffer);
   for (int i = 0; i < codec.frameCount; i++) {
     final frameInfo = await codec.getNextFrame();
     final duration = frameInfo.duration.inSeconds;


### PR DESCRIPTION
This pull request solves the issue with using `PaintingBinding.instantiateImageCodec` on Flutter version `3.16.9`.

Issue: https://github.com/saytoonz/flutter_gif/issues/12